### PR TITLE
New log cats & handle ctx == nil

### DIFF
--- a/log_cat.go
+++ b/log_cat.go
@@ -12,86 +12,136 @@ type LogCat struct {
 // be registered in the `allLogCats` slice below.
 var (
 	// LogCatStartUp usage: service startup logs
-	LogCatStartUp = LogCat{Code: "STT01", Type: "service_startup"}
+	LogCatStartUp = LogCat{Code: "STT001", Type: "service_startup"}
 
 	// LogCatHealth usage: health check logs
-	LogCatHealth = LogCat{Code: "HTH01", Type: "health_check"}
+	LogCatHealth = LogCat{Code: "HTH001", Type: "health_check"}
 
 	// LogCatRouterInit usage: api router setup logs
-	LogCatRouterInit = LogCat{Code: "RTR01", Type: "router_initialization"}
+	LogCatRouterInit = LogCat{Code: "RTR001", Type: "router_initialization"}
 
 	// LogCatRepoInit usage: repository setup logs
-	LogCatRepoInit = LogCat{Code: "RPO01", Type: "repo_initialization"}
+	LogCatRepoInit = LogCat{Code: "RPO001", Type: "repo_initialization"}
 
 	// LogCatRepoOutput usage: logs relating to
 	// the results of repository layer functions/methods
-	LogCatRepoOutput = LogCat{Code: "RPO02", Type: "repository_output"}
+	LogCatRepoOutput = LogCat{Code: "RPO002", Type: "repository_output"}
 
 	// LogCatReadConfig usage: configuration reading/init logs
-	LogCatReadConfig = LogCat{Code: "CNF01", Type: "read_configuration"}
+	LogCatReadConfig = LogCat{Code: "CNF001", Type: "read_configuration"}
 
 	// LogCatDatastoreConnect usage: datastore connect
 	// logs (more specific than LogCatRepoInit)
-	LogCatDatastoreConnect = LogCat{Code: "DTA01", Type: "datastore_connect"}
+	LogCatDatastoreConnect = LogCat{Code: "DTA001", Type: "datastore_connect"}
 
 	// LogCatDatastoreClose usage: close datastore connection logs
-	LogCatDatastoreClose = LogCat{Code: "DTA02", Type: "datastore_close"}
+	LogCatDatastoreClose = LogCat{Code: "DTA002", Type: "datastore_close"}
 
 	// LogCatDatabase usage: datastore interaction
 	// logs, e.g. query exec or record read errors
-	LogCatDatabase = LogCat{Code: "DTA03", Type: "datastore_interaction"}
+	LogCatDatabase = LogCat{Code: "DTA003", Type: "datastore_interaction"}
 
 	// LogCatMarshallJSON usage: JSON marshalling logs,
 	// i.e. logs for events when converting data or data structures to JSON
-	LogCatMarshallJSON = LogCat{Code: "JSN01", Type: "marshall_json"}
+	LogCatMarshallJSON = LogCat{Code: "JSN001", Type: "marshall_json"}
 
 	// LogCatUnmarshalReq usage: request decoding logs,
 	// i.e. events relating to the deserialization of incoming requests
-	LogCatUnmarshalReq = LogCat{Code: "REQ01", Type: "unmarshal_request_payload"}
+	LogCatUnmarshalReq = LogCat{Code: "REQ001", Type: "unmarshal_request_payload"}
+
+	// LogCatFileRead usage: logs relating to file reads
+	LogCatFileRead = LogCat{Code: "FIL001", Type: "file_read"}
+
+	// LogCatFileWrite usage: logs relating to file writes
+	LogCatFileWrite = LogCat{Code: "FIL002", Type: "file_write"}
+
+	// LogCatTLSLoadCerts usage: logs relating to reading in tls certificates
+	LogCatTLSLoadCerts = LogCat{Code: "TLS001", Type: "tls_load_certs"}
 
 	// LogCatAPIKey usage: logs regarding the api-key of an incoming request
-	LogCatAPIKey = LogCat{Code: "REQ02", Type: "request_apikey"}
+	LogCatAPIKey = LogCat{Code: "REQ002", Type: "request_apikey"}
 
 	// LogCatReqPath usage: logs of the path of an incoming request
-	LogCatReqPath = LogCat{Code: "REQ03", Type: "request_path"}
+	LogCatReqPath = LogCat{Code: "REQ003", Type: "request_path"}
 
 	// LogCatReqValid usage: logs regarding validating an incoming request
-	LogCatReqValid = LogCat{Code: "REQ04", Type: "request_validation"}
+	LogCatReqValid = LogCat{Code: "REQ004", Type: "request_validation"}
 
 	// LogCatDebug usage: debug-related logs
-	LogCatDebug = LogCat{Code: "DBG01", Type: "debug"}
+	LogCatDebug = LogCat{Code: "DBG001", Type: "debug"}
 
 	// LogCatTypeConv usage: logs regarding the conversion
 	// of data from one type to another e.g. string to integer conversion errors
-	LogCatTypeConv = LogCat{Code: "CNV01", Type: "type_conversion"}
+	LogCatTypeConv = LogCat{Code: "CNV001", Type: "type_conversion"}
 
 	// LogCatDateTimeParse usage: date/time string parsing logs
-	LogCatDateTimeParse = LogCat{Code: "PRS01", Type: "datetime_parse"}
+	LogCatDateTimeParse = LogCat{Code: "PRS001", Type: "datetime_parse"}
 
 	// LogCatServiceOutput usage: logs relating to the
 	// results of service layer functions/methods
-	LogCatServiceOutput = LogCat{Code: "SRV01", Type: "service_layer_output"}
+	LogCatServiceOutput = LogCat{Code: "SRV001", Type: "service_layer_output"}
 
 	// LogCatInputValidation usage: logs relating to validating
 	// the input parameters of a method/function
-	LogCatInputValidation = LogCat{Code: "VAL01", Type: "method_input_validation"}
+	LogCatInputValidation = LogCat{Code: "VAL001", Type: "method_input_validation"}
+
+	// LogCatInvalidType can be used for logs concerning type validation or casting
+	LogCatInvalidType = LogCat{Code: "VAL002", Type: "type_validation"}
 
 	// LogCatTemplateExec usage: logs relating to "executing" on a golang template
-	LogCatTemplateExec = LogCat{Code: "TMP01", Type: "template_execution"}
+	LogCatTemplateExec = LogCat{Code: "TMP001", Type: "template_execution"}
 
 	// LogCatCacheInit usage: logs relating to cache initialization
-	LogCatCacheInit = LogCat{Code: "CCH01", Type: "cache_initialize"}
+	LogCatCacheInit = LogCat{Code: "CCH001", Type: "cache_initialize"}
 
 	// LogCatCacheRead usage: logs relating to reading from a cache
-	LogCatCacheRead = LogCat{Code: "CCH02", Type: "cache_read"}
+	LogCatCacheRead = LogCat{Code: "CCH002", Type: "cache_read"}
 
 	// LogCatCacheWrite usage: logs relating to writing to a cache
-	LogCatCacheWrite = LogCat{Code: "CCH03", Type: "cache_write"}
+	LogCatCacheWrite = LogCat{Code: "CCH003", Type: "cache_write"}
 
 	// LogCatImplStatus usage: logs relating to the implementation progress of any particular
 	// service functionality. E.g. an endpoint exists and is hit, but the intended functionality has
 	// not yet been implemented
-	LogCatImplStatus = LogCat{Code: "STS01", Type: "implementation_status"}
+	LogCatImplStatus = LogCat{Code: "STS001", Type: "implementation_status"}
+
+	// LogCatKafkaSchemaReg usage: logs relating to initializing or
+	// interating with a kafka schema registry
+	LogCatKafkaSchemaReg = LogCat{Code: "KFK001", Type: "kafka_schemareg_init"}
+
+	// LogCatKafkaDecode usage: logs relating to decoding kafka messages
+	LogCatKafkaDecode = LogCat{Code: "KFK002", Type: "kafka_message_decode"}
+
+	// LogCatKafkaEncode usage: logs relating to encoding kafka messages
+	LogCatKafkaEncode = LogCat{Code: "KFK003", Type: "kafka_message_encode"}
+
+	// LogCatKafkaConsumerInit usage: logs relating to initializing a kafka consumer
+	LogCatKafkaConsumerInit = LogCat{Code: "KFK004", Type: "kafka_consumer_init"}
+
+	// LogCatKafkaProducerInit usage: logs relating to initializing a kafka producer
+	LogCatKafkaProducerInit = LogCat{Code: "KFK005", Type: "kafka_producer_init"}
+
+	// LogCatKafkaConsumerClose usage: logs relating to attempting to close a kafka consumer
+	LogCatKafkaConsumerClose = LogCat{Code: "KFK006", Type: "kafka_consumer_close"}
+
+	// LogCatKafkaConsume usage: logs relating to the consumption of kafka messages
+	LogCatKafkaConsume = LogCat{Code: "KFK007", Type: "kafka_consume"}
+
+	// LogCatKafkaProduce usage: logs relating to the production of kafka messages
+	LogCatKafkaProduce = LogCat{Code: "KFK008", Type: "kafka_produce"}
+
+	// LogCatKafkaConfig usage: logs relating to configuring a kafka integration
+	LogCatKafkaConfig = LogCat{Code: "KFK009", Type: "kafka_configure"}
+
+	// LogCatKafkaProcessMessage usage: logs relating to the processing of kafka messages
+	LogCatKafkaProcessMessage = LogCat{Code: "KFK010", Type: "kafka_process_message"}
+
+	// LogCatKafkaCommitOffset usage: logs relating to committing offsets after reading
+	// and successfully processing a kafka message and its contents
+	LogCatKafkaCommitOffset = LogCat{Code: "KFK011", Type: "kafka_commit_offset"}
+
+	// LogCatExternal usage: miscellaneous external library operation logs
+	LogCatExternal = LogCat{Code: "EXT001", Type: "external_lib_op"}
 
 	// LogCatUncategorized usage: for temporary use in development if there has not yet
 	// been an adequate category added. If this is the case, please
@@ -115,6 +165,9 @@ var allLogCats = []LogCat{
 	LogCatDatabase,
 	LogCatMarshallJSON,
 	LogCatUnmarshalReq,
+	LogCatFileRead,
+	LogCatFileWrite,
+	LogCatTLSLoadCerts,
 	LogCatAPIKey,
 	LogCatReqPath,
 	LogCatReqValid,
@@ -123,9 +176,22 @@ var allLogCats = []LogCat{
 	LogCatDateTimeParse,
 	LogCatServiceOutput,
 	LogCatInputValidation,
+	LogCatInvalidType,
 	LogCatTemplateExec,
 	LogCatCacheInit,
 	LogCatCacheRead,
 	LogCatCacheWrite,
 	LogCatImplStatus,
+	LogCatKafkaSchemaReg,
+	LogCatKafkaDecode,
+	LogCatKafkaEncode,
+	LogCatKafkaConsumerInit,
+	LogCatKafkaProducerInit,
+	LogCatKafkaConsumerClose,
+	LogCatKafkaConsume,
+	LogCatKafkaProduce,
+	LogCatKafkaConfig,
+	LogCatKafkaProcessMessage,
+	LogCatKafkaCommitOffset,
+	LogCatExternal,
 	LogCatUncategorized}

--- a/logger.go
+++ b/logger.go
@@ -28,6 +28,11 @@ const (
 	// Depth of the callstack - needed to determine
 	// the initial caller function, for example
 	depth int = 5
+
+	prefixInfo  = "INFO "
+	prefixWarn  = "WARN "
+	prefixError = "ERROR "
+	prefixFatal = "FATAL "
 )
 
 // Logger struct
@@ -64,24 +69,12 @@ func New(ctx context.Context, outPath string) *Logger {
 		errOutput = io.MultiWriter(file, errOutput)
 	}
 
-	id, ok := ctx.Value(RequestIDKey).(string)
-	if !ok {
-		id = ""
-	}
-
-	apiKey, ok := ctx.Value(APIKEY).(string)
-	if !ok {
-		apiKey = ""
-	}
-
-	addr, ok := ctx.Value(RemoteAddrKey).(string)
-	if !ok {
-		addr = ""
-	}
-
-	session, ok := ctx.Value(SessionIDKey).(string)
-	if !ok {
-		addr = ""
+	var id, apiKey, addr, session string
+	if ctx != nil {
+		id, _ = ctx.Value(RequestIDKey).(string)
+		apiKey, _ = ctx.Value(APIKEY).(string)
+		addr, _ = ctx.Value(RemoteAddrKey).(string)
+		session, _ = ctx.Value(SessionIDKey).(string)
 	}
 
 	return &Logger{
@@ -112,7 +105,7 @@ func (l *Logger) printlnf(logger *log.Logger, logCat LogCat, format string, v ..
 
 func (l *Logger) Info(logCat LogCat, v ...interface{}) {
 	if l.infoLog == nil {
-		l.infoLog = log.New(l.output, "INFO ", log.Ldate|log.Ltime)
+		l.infoLog = log.New(l.output, prefixInfo, log.Ldate|log.Ltime)
 	}
 
 	l.println(l.infoLog, logCat, v...)
@@ -121,7 +114,7 @@ func (l *Logger) Info(logCat LogCat, v ...interface{}) {
 // Infof prints a message using the specified format.
 func (l *Logger) Infof(logCat LogCat, format string, v ...interface{}) {
 	if l.infoLog == nil {
-		l.infoLog = log.New(l.output, "INFO ", log.Ldate|log.Ltime)
+		l.infoLog = log.New(l.output, prefixInfo, log.Ldate|log.Ltime)
 	}
 
 	l.printlnf(l.infoLog, logCat, format, v...)
@@ -130,7 +123,7 @@ func (l *Logger) Infof(logCat LogCat, format string, v ...interface{}) {
 // InfoWF prints message using Fields struct to pass multiple key=value pairs.
 func (l *Logger) InfoWF(logCat LogCat, fields *Fields) {
 	if l.infoLog == nil {
-		l.infoLog = log.New(l.output, "INFO ", log.Ldate|log.Ltime)
+		l.infoLog = log.New(l.output, prefixInfo, log.Ldate|log.Ltime)
 	}
 
 	l.printlnWF(l.infoLog, logCat, fields)
@@ -138,7 +131,7 @@ func (l *Logger) InfoWF(logCat LogCat, fields *Fields) {
 
 func (l *Logger) Warn(logCat LogCat, v ...interface{}) {
 	if l.warningLog == nil {
-		l.warningLog = log.New(l.output, "WARNING ", log.Ldate|log.Ltime)
+		l.warningLog = log.New(l.output, prefixWarn, log.Ldate|log.Ltime)
 	}
 
 	l.println(l.warningLog, logCat, v...)
@@ -146,7 +139,7 @@ func (l *Logger) Warn(logCat LogCat, v ...interface{}) {
 
 func (l *Logger) Warnf(logCat LogCat, format string, v ...interface{}) {
 	if l.warningLog == nil {
-		l.warningLog = log.New(l.output, "WARNING ", log.Ldate|log.Ltime)
+		l.warningLog = log.New(l.output, prefixWarn, log.Ldate|log.Ltime)
 	}
 
 	l.printlnf(l.warningLog, logCat, format, v...)
@@ -155,7 +148,7 @@ func (l *Logger) Warnf(logCat LogCat, format string, v ...interface{}) {
 // WarnWF prints message with fields to use multiple key=value pairs.
 func (l *Logger) WarnWF(logCat LogCat, fields *Fields) {
 	if l.warningLog == nil {
-		l.warningLog = log.New(l.output, "WARNING ", log.Ldate|log.Ltime)
+		l.warningLog = log.New(l.output, prefixWarn, log.Ldate|log.Ltime)
 	}
 	l.printlnWF(l.warningLog, logCat, fields)
 }
@@ -163,7 +156,7 @@ func (l *Logger) WarnWF(logCat LogCat, fields *Fields) {
 // Error prints message at error level.
 func (l *Logger) Error(logCat LogCat, v ...interface{}) {
 	if l.errorLog == nil {
-		l.errorLog = log.New(l.errOutput, "ERROR ", log.Ldate|log.Ltime)
+		l.errorLog = log.New(l.errOutput, prefixError, log.Ldate|log.Ltime)
 	}
 
 	l.println(l.errorLog, logCat, v...)
@@ -172,7 +165,7 @@ func (l *Logger) Error(logCat LogCat, v ...interface{}) {
 // Errorf prints message at error level.
 func (l *Logger) Errorf(logCat LogCat, format string, v ...interface{}) {
 	if l.errorLog == nil {
-		l.errorLog = log.New(l.errOutput, "ERROR ", log.Ldate|log.Ltime)
+		l.errorLog = log.New(l.errOutput, prefixError, log.Ldate|log.Ltime)
 	}
 
 	l.printlnf(l.errorLog, logCat, format, v...)
@@ -181,7 +174,7 @@ func (l *Logger) Errorf(logCat LogCat, format string, v ...interface{}) {
 // ErrorWF prints message at error level using Fields with multiple key=value pairs.
 func (l *Logger) ErrorWF(logCat LogCat, fields *Fields) {
 	if l.errorLog == nil {
-		l.errorLog = log.New(l.errOutput, "ERROR ", log.Ldate|log.Ltime)
+		l.errorLog = log.New(l.errOutput, prefixError, log.Ldate|log.Ltime)
 	}
 
 	l.printlnWF(l.errorLog, logCat, fields)
@@ -193,7 +186,7 @@ func (l *Logger) Fatal(logCat LogCat, v ...interface{}) {
 		l.errorLog = log.New(l.errOutput, "", log.Ldate|log.Ltime)
 	}
 
-	l.errorLog.SetPrefix("FATAL ")
+	l.errorLog.SetPrefix(prefixFatal)
 	l.errorLog.Fatal(finalMessage(l, logCat, v...))
 }
 
@@ -203,7 +196,7 @@ func (l *Logger) Fatalf(logCat LogCat, format string, v ...interface{}) {
 		l.errorLog = log.New(l.errOutput, "", log.Ldate|log.Ltime)
 	}
 
-	l.errorLog.SetPrefix("FATAL ")
+	l.errorLog.SetPrefix(prefixFatal)
 	l.errorLog.Fatal(finalMessagef(l, logCat, format, v...))
 }
 
@@ -213,6 +206,6 @@ func (l *Logger) FatalWF(logCat LogCat, fields *Fields) {
 		l.errorLog = log.New(l.errOutput, "", log.Ldate|log.Ltime)
 	}
 
-	l.errorLog.SetPrefix("FATAL ")
+	l.errorLog.SetPrefix(prefixFatal)
 	l.errorLog.Fatal(finalMessageWF(l, logCat, fields))
 }

--- a/main_test.go
+++ b/main_test.go
@@ -7,13 +7,6 @@ import (
 	"testing"
 )
 
-// import (
-// 	"context"
-// 	"net/http"
-// 	"strings"
-// 	"testing"
-// )
-
 func TestNew(t *testing.T) {
 	apiKey := "r12d3f4"
 	requestID := "1234"


### PR DESCRIPTION
## Description

- Added new logging categories (mainly for kafka-related logs)
- Added code to handle a nil context passed in to `New()` (valid scenario, especially if we need to log operations that are outside of the web rq/rs scope - like with kafka message consumption/processing)
- Small cleaning up